### PR TITLE
Fix config validation condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,9 +292,9 @@ const testConfig = config => {
 
 // exposes factory
 module.exports = function(config) {
-	if (config && typeof config !== "object" && !Array.isArray(config)) {
-		throw new Error("config argument must be an object")
-	}
+       if (config && (typeof config !== "object" || Array.isArray(config))) {
+               throw new Error("config argument must be an object")
+       }
 
 	let	model = require("./data/model.json");
 


### PR DESCRIPTION
## Summary
- expand module factory config check to detect arrays

## Testing
- `npm test` *(fails: `mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f998081b8832d8ceb313f2ea3bd89